### PR TITLE
Use create-hash / Bump version / Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "ripple-address-codec",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "encodes/decodes base58 encoded ripple identifiers",
   "main": "src/index.js",
   "license": "ISC",
   "dependencies": {
-    "hash.js": "^1.0.3",
-    "x-address-codec": "^0.7.0"
+    "create-hash": "^1.1.2",
+    "x-address-codec": "^0.7.2"
   },
   "repository": {
     "type": "git",
@@ -20,9 +20,9 @@
   },
   "devDependencies": {
     "coveralls": "~2.11.4",
-    "eslint": "^1.4.3",
-    "istanbul": "~0.3.20",
-    "mocha": "^2.3.2"
+    "eslint": "^1.5.1",
+    "istanbul": "~0.3.21",
+    "mocha": "^2.3.3"
   },
   "readmeFilename": "README.md",
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var hashjs = require('hash.js');
+var createHash = require('create-hash');
 var apiFactory = require('x-address-codec');
 
 var NODE_PUBLIC = 28;
@@ -11,7 +11,7 @@ var ED25519_SEED = [0x01, 0xE1, 0x4B];
 
 module.exports = apiFactory({
   sha256: function(bytes) {
-    return hashjs.sha256().update(bytes).digest();
+    return createHash('sha256').update(new Buffer(bytes)).digest();
   },
   defaultAlphabet: 'ripple',
   codecMethods: {


### PR DESCRIPTION
Use create-hash, which will use native node modules where possible, or pure javascript implementations when constrained by the browser environment. Also take the opportunity to update the dependencies and bump the version.