### PR TITLE
Correct X-address to classic address example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Convert an X-address to a classic address and tag. If the X-address did not have
 
 ```js
 > const api = require('ripple-address-codec')
-> rippleAddressCodec.xAddressToClassicAddress('XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHi')
+> api.xAddressToClassicAddress('XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHi')
 {
   classicAddress: 'rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf',
   tag: 4294967295,
-  test: true
+  test: false
 }
 ```
 


### PR DESCRIPTION
The example made no sense due to `test` being set to true, but an X-address with prefix X was used. 

Note regarding the `test` boolean, since the standard never mentioned it (@nbougalis, https://github.com/xrp-community/standards-drafts/issues/6), there's already two variations being used. `test` as used by this library and `testnet` as used by XRPL Labs implementation (https://github.com/xrp-community/xrpl-tagged-address-codec#2-encode--decode), maybe we could agree on one and include that in the standard?